### PR TITLE
Call e.preventDefault() before core-activate

### DIFF
--- a/core-selector.html
+++ b/core-selector.html
@@ -380,6 +380,7 @@ Fired when an item element is tapped.
       // event fired from host
       activateHandler: function(e) {
         if (!this.notap) {
+          e.preventDefault();
           var i = this.findDistributedTarget(e.target, this.items);
           if (i >= 0) {
             var item = this.items[i];


### PR DESCRIPTION
On iOS if a paper-tabs is clicked then the tap event is forwarded to element in the same position after scrolling.
