### PR TITLE
Adjust some type docs for selected and selectedItem

### DIFF
--- a/core-selector.html
+++ b/core-selector.html
@@ -105,7 +105,7 @@ Fired when an item element is tapped.
        *     this.$.selector.selected = ['foo', 'zot'];
        *
        * @attribute selected
-       * @type Object
+       * @type *
        * @default null
        */
       selected: null,
@@ -164,7 +164,7 @@ Fired when an item element is tapped.
        * `selected`.
        * 
        * @attribute selectedItem
-       * @type Object
+       * @type Element|Array<Element>
        * @default null
        */
       selectedItem: null,


### PR DESCRIPTION
Make the type of selected \* since it should be able to accept strings, numbers, and arrays in addition to Objects. Also tighten selectedItem to Element|Array<Element>.
