### PR TITLE
Fixed problem with values that are Array properties

### DIFF
--- a/core-selector.html
+++ b/core-selector.html
@@ -423,8 +423,9 @@ Fired when an item element is tapped.
       },
 
       valueToItem: function(value) {
-        return (value === null || value === undefined) ?
+        var item = (value === null || value === undefined) ?
             null : this.items[this.valueToIndex(value)];
+        return (this.items.indexOf(item) === -1) ? null : item;
       },
 
       valueToIndex: function(value) {


### PR DESCRIPTION
If the value is 'filter', 'map', ... the method returns a function and not an object
